### PR TITLE
Sanitize request headers and improve CRUD progress and arg handling

### DIFF
--- a/src/core/http-client.js
+++ b/src/core/http-client.js
@@ -13,7 +13,8 @@ function buildUrl(baseUrl, rawUrlTemplate, pathParams = {}) {
   let url = rawUrlTemplate.replace('{{baseUrl}}', baseUrl).replace('{{site}}', baseUrl.split('.').slice(-2).join('.'));
   
   for (const [key, value] of Object.entries(pathParams)) {
-    url = url.replace(`:${key}`, encodeURIComponent(String(value)));
+    const encoded = encodeURIComponent(String(value));
+    url = url.replaceAll(`:${key}`, encoded).replaceAll(`{${key}}`, encoded);
   }
   
   return url;
@@ -31,6 +32,17 @@ function buildQueryString(params) {
   
   const queryString = searchParams.toString();
   return queryString ? `?${queryString}` : '';
+}
+
+function sanitizeHeaders(headers) {
+  if (!headers || typeof headers !== 'object') return {};
+  const forbiddenHeaders = new Set(['dd-api-key', 'dd-application-key', 'user-agent']);
+  return Object.fromEntries(
+    Object.entries(headers).filter(([key, value]) => {
+      if (value === undefined || value === null) return false;
+      return !forbiddenHeaders.has(String(key).toLowerCase());
+    })
+  );
 }
 
 function sleep(ms) {
@@ -53,12 +65,13 @@ export class DatadogClient {
     timeoutMs,
   }) {
     const url = buildUrl(this.baseUrl, rawUrlTemplate, pathParams) + buildQueryString(query);
+    const safeHeaders = sanitizeHeaders(headers);
     const requestHeaders = {
       'DD-API-KEY': this.config.credentials.apiKey,
       'DD-APPLICATION-KEY': this.config.credentials.appKey,
       'User-Agent': this.config.userAgent,
       'Accept': 'application/json',
-      ...headers,
+      ...safeHeaders,
     };
 
     if (body && method !== 'GET' && method !== 'HEAD') {

--- a/src/tools/crud-tools.js
+++ b/src/tools/crud-tools.js
@@ -340,6 +340,14 @@ const DATADOG_RESOURCES = {
 
 function createCrudTool(resource, operation, operationConfig) {
   const toolName = `${operation}_${resource}`;
+  const operationLabel = `${operation.charAt(0).toUpperCase() + operation.slice(1)}`;
+  const operationAction = {
+    create: 'Creating',
+    update: 'Updating',
+    delete: 'Deleting',
+    list: 'Listing',
+    get: 'Getting',
+  }[operation] || `${operationLabel}ing`;
 
   return {
     name: toolName,
@@ -366,23 +374,22 @@ function createCrudTool(resource, operation, operationConfig) {
         progressCallback(createProgressResponse({
           step: 0,
           total: 100,
-          message: `${operation.charAt(0).toUpperCase() + operation.slice(1)}ing ${resource}...`,
+          message: `${operationAction} ${resource}...`,
         }));
       }
 
       try {
-        // Replace path parameters in endpoint
-        let endpoint = operationConfig.endpoint;
+        const endpoint = operationConfig.endpoint;
         const pathParams = {};
+        const pathParamKeys = [...endpoint.matchAll(/{([^}]+)}/g)].map(match => match[1]);
+        const remainingArgs = { ...args };
 
-        // Extract path parameters from args
-        Object.keys(args).forEach(key => {
-          if (endpoint.includes(`{${key}}`)) {
-            pathParams[key] = args[key];
-            endpoint = endpoint.replace(`{${key}}`, args[key]);
-            delete args[key];
+        for (const key of pathParamKeys) {
+          if (Object.prototype.hasOwnProperty.call(remainingArgs, key)) {
+            pathParams[key] = remainingArgs[key];
+            delete remainingArgs[key];
           }
-        });
+        }
 
         if (showProgress && progressCallback) {
           progressCallback(createProgressResponse({
@@ -401,9 +408,9 @@ function createCrudTool(resource, operation, operationConfig) {
         };
 
         if (operationConfig.method === 'GET') {
-          requestConfig.query = args;
+          requestConfig.query = remainingArgs;
         } else {
-          requestConfig.body = args;
+          requestConfig.body = remainingArgs;
         }
 
         const response = await client.request(requestConfig);
@@ -421,7 +428,7 @@ function createCrudTool(resource, operation, operationConfig) {
           progressCallback(createProgressResponse({
             step: 100,
             total: 100,
-            message: `${operation.charAt(0).toUpperCase() + operation.slice(1)} ${resource} completed successfully`,
+            message: `${operationLabel} ${resource} completed successfully`,
           }, response.data));
         }
 
@@ -438,7 +445,7 @@ function createCrudTool(resource, operation, operationConfig) {
           progressCallback(createProgressResponse({
             step: 0,
             total: 100,
-            message: `${operation.charAt(0).toUpperCase() + operation.slice(1)} ${resource} failed: ${error.message}`,
+            message: `${operationLabel} ${resource} failed: ${error.message}`,
           }));
         }
 


### PR DESCRIPTION
### Motivation
- Fix a header override vulnerability by preventing callers from injecting authentication or user-agent headers into requests.
- Ensure path parameter insertion is safe and consistently encoded to avoid malformed URLs.
- Avoid mutating caller-supplied `args` when extracting path parameters to preserve input integrity.
- Make CRUD progress messages grammatically consistent and clearer by using action verbs.

### Description
- Add `sanitizeHeaders` in `src/core/http-client.js` to filter out `DD-API-KEY`, `DD-APPLICATION-KEY`, and `User-Agent` overrides and merge only safe headers into the request.
- Use the sanitized headers when building `requestHeaders` in the `DatadogClient.request` flow in `src/core/http-client.js`.
- Harden `buildUrl` to `encodeURIComponent` path values and replace both `:{param}` and `{param}` templates using `replaceAll` in `src/core/http-client.js`.
- Update `src/tools/crud-tools.js` to compute `pathParamKeys` with `matchAll`, use a `remainingArgs` copy instead of mutating `args`, and introduce `operationLabel`/`operationAction` to standardize progress and completion messages.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69651ac81b5c832587e59dad5bf3de32)