### PR TITLE
Fix invalid MCP property keys by sanitizing bracket notation

### DIFF
--- a/src/core/schema-parser.js
+++ b/src/core/schema-parser.js
@@ -25,6 +25,10 @@ function normalizeOperationName(name) {
     .replace(/_+/g, '_');
 }
 
+function sanitizeParamKey(key) {
+  return key.replace(/[^a-zA-Z0-9_.-]/g, '_').replace(/_+/g, '_').replace(/^_+|_+$/g, '');
+}
+
 function parseOperation(item, category) {
   if (!item.request) return null;
   
@@ -55,11 +59,13 @@ function parseOperation(item, category) {
   if (request.url?.query) {
     for (const query of request.url.query) {
       if (query.key) {
-        queryParams[query.key] = {
+        const safeKey = sanitizeParamKey(query.key);
+        queryParams[safeKey] = {
           type: 'string',
           description: query.description || `Query parameter: ${query.key}`,
           required: !query.disabled,
           example: query.value,
+          originalKey: query.key !== safeKey ? query.key : undefined,
         };
       }
     }

--- a/src/tools/core-tools.js
+++ b/src/tools/core-tools.js
@@ -55,11 +55,18 @@ export function createCoreTool(operation, client) {
         const { path: pathParams, query, body, headers, ...rest } = args;
         const mergedQuery = { ...query, ...rest };
 
+        const resolvedQuery = {};
+        for (const [key, value] of Object.entries(mergedQuery)) {
+          const paramDef = operation.queryParams?.[key];
+          const originalKey = paramDef?.originalKey || key;
+          resolvedQuery[originalKey] = value;
+        }
+
         const response = await client.request({
           method: operation.method,
           rawUrlTemplate: operation.rawUrlTemplate,
           pathParams,
-          query: mergedQuery,
+          query: resolvedQuery,
           body,
           headers,
         });


### PR DESCRIPTION
Datadog API query parameters like `page[size]` and `filter[query]` contain brackets which violate the MCP property key pattern ^[a-zA-Z0-9_.-]{1,64}$. Sanitize keys to underscores (e.g. page_size) and store the original key so it is restored when making the actual HTTP request.


Claude-Session: https://claude.ai/code/session_01W83Nqp3nP9Qbgpbu64XnTa